### PR TITLE
Kubernetes Task-1 YAML Manifests

### DIFF
--- a/k8s-deployment-1/README.md
+++ b/k8s-deployment-1/README.md
@@ -1,0 +1,49 @@
+# Assignment 1: Nginx Deployment on Kubernetes
+
+This repository contains Kubernetes manifests to deploy a basic nginx deployment.
+
+---
+
+## Prerequisites
+
+* Kubernetes cluster (Minikube/Kind/other)
+* `kubectl` CLI installed
+* Docker
+
+---
+
+
+   
+   # Deploy StatefulSet for PostgreSQL or other stateful app
+
+    # Deploy Statefulset
+    kubectl apply -f statefulset.yaml
+
+    # Deploy Services
+    kubectl apply -f service.yaml
+
+    # Deploy backend application with environment variables (Secrets & ConfigMaps)
+    kubectl apply -f env-deployment.yaml
+
+    # Deploy other application deployments (if any)
+    kubectl apply -f deployment.yaml
+
+    # Mount JSON config file via ConfigMap/Secret in a deployment
+    kubectl apply -f json-config-deployment.yaml
+
+    # Apply Ingress to route external traffic
+    kubectl apply -f ingress.yaml
+
+    # Verify Pods, Services, PVCs, and Ingress
+    kubectl get pods
+    kubectl get svc
+    kubectl get pvc
+    kubectl get ingress
+
+    # View logs of a specific pod
+    kubectl logs <pod-name>
+
+    # Exec into a running pod
+    kubectl exec -it <pod-name> -- /bin/bash
+
+

--- a/k8s-deployment-1/README.md
+++ b/k8s-deployment-1/README.md
@@ -14,7 +14,6 @@ This repository contains Kubernetes manifests to deploy a basic nginx deployment
 
 
    
-   # Deploy StatefulSet for PostgreSQL or other stateful app
 
     # Deploy Statefulset
     kubectl apply -f statefulset.yaml

--- a/k8s-deployment-1/config.yaml
+++ b/k8s-deployment-1/config.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: json-config
+data:
+  config.json: |
+    {
+      api_key: 12345,
+      environment: dev
+    }
+

--- a/k8s-deployment-1/nginx-deployment.yaml
+++ b/k8s-deployment-1/nginx-deployment.yaml
@@ -1,0 +1,38 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: nginx-deployment
+spec:
+  replicas: 3
+  selector:
+    matchLabels:
+      app: nginx
+  template:
+    metadata:
+      labels:
+        app: nginx
+    spec:
+      containers:
+      - name: nginx
+        image: nginx:latest
+        ports:
+        - containerPort: 80
+        env:
+        - name: ENV
+          valueFrom:
+            configMapKeyRef:
+              name: app-config
+              key: ENV
+        - name: DB_PASS
+          valueFrom:
+            secretKeyRef:
+              name: db-secret
+              key: DB_PASS
+        volumeMounts:
+        - name: config-volume
+          mountPath: /app/config.json
+          subPath: config.json
+      volumes:
+      - name: config-volume
+        configMap:
+          name: json-config

--- a/k8s-deployment-1/nginx-ingress.yaml
+++ b/k8s-deployment-1/nginx-ingress.yaml
@@ -1,0 +1,17 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: nginx-ingress
+spec:
+  rules:
+  - host: nginx.local
+    http:
+      paths:
+      - path: /
+        pathType: Prefix
+        backend:
+          service:
+            name: nginx-service
+            port:
+              number: 80
+

--- a/k8s-deployment-1/nginx-service.yaml
+++ b/k8s-deployment-1/nginx-service.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Service
+metadata:
+ name: nginx-service
+spec:
+ type: NodePort
+ selector:
+  app: nginx
+ ports:
+  protocol: TCP
+  port: 80 
+  targetPort: 80
+

--- a/k8s-deployment-1/nginx-statefulset.yaml
+++ b/k8s-deployment-1/nginx-statefulset.yaml
@@ -1,0 +1,30 @@
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: web
+spec:
+  serviceName: nginx
+  replicas: 2
+  selector:
+    matchLabels:
+      app: nginx
+  template:
+    metadata:
+      labels:
+        app: nginx
+    spec:
+      containers:
+      - name: nginx
+        image: nginx
+        volumeMounts:
+        - name: www
+          mountPath: /usr/share/nginx/html
+  volumeClaimTemplates:
+  - metadata:
+      name: www
+    spec:
+      accessModes: [ ReadWriteOnce ]
+      resources:
+        requests:
+          storage: 1Gi
+


### PR DESCRIPTION
###  Overview  
This pull request describes Kubernetes operations using a local **Minikube** setup. 


###  Tasks Completed

- **Created Nginx Deployment with 3 Replicas**  
  - Used `kubectl apply` to create a Deployment with 3 replicas of the Nginx container.

- **Exposed Deployment via Service**  
  - Created a **NodePort** service to expose the Nginx deployment and allow external access.

- **Accessed Nginx in Browser**  
  - Verified browser access using the Minikube IP and NodePort.

- **Scaled Replicas Up and Down**  
  - Scaled the Nginx deployment down to 0 replicas, then back up to 1, demonstrating elasticity with:
    ```bash
    kubectl scale deployment nginx-deployment --replicas=0
    kubectl scale deployment nginx-deployment --replicas=1
    ```

- **Exec into Nginx Pod**  
  - Used `kubectl exec` to open a shell inside the running Nginx pod.
  - Verified internal DNS by accessing the service name from within the pod.

- **Viewed Pod Logs**  
  - Inspected pod logs using `kubectl logs <pod-name>` .

- **Described and Inspected Resources**  
  - Used `kubectl get` and `kubectl describe` to check:
    - Pod status
    - Deployment status
    - Events and error messages

- **Created Ingress Resource**  
  - Defined an Ingress object to route HTTP traffic to the Nginx service.

- **Created a StatefulSet with PVC**  
  - Deployed a basic StatefulSet to illustrate identity and persistent storage.
  - Bound each pod to its own **PersistentVolumeClaim (PVC)** for durable storage.

- **Used ConfigMaps and Secrets with ENV Variables**  
  - Created Kubernetes **Secrets** and **ConfigMaps**.
  - Injected values into a Deployment as environment variables.

- **Mounted JSON File Using ConfigMap/Secrets**  
  - Created a ConfigMapfrom a `.json` file.
  - Mounted it into a Deployment pod as a file using a volume mount.
